### PR TITLE
fix: add missing `rounded-bg` to Nav SocialLinks

### DIFF
--- a/src/components/icons/GitHub.tsx
+++ b/src/components/icons/GitHub.tsx
@@ -11,7 +11,7 @@ export const GitHub = (
         role="link"
         aria-label="Shriram's Github profile"
         className={cn(
-          "group inline-flex cursor-pointer items-center p-2 px-3 text-center text-current",
+          "group inline-flex cursor-pointer items-center rounded-lg p-2 px-3 text-center text-current",
           props.className
         )}
         tabIndex={0}

--- a/src/components/icons/Linkedin.tsx
+++ b/src/components/icons/Linkedin.tsx
@@ -11,7 +11,7 @@ export const Linkedin = (
         role="link"
         aria-label="Shriram's Linkedin profile"
         className={cn(
-          "group inline-flex cursor-pointer items-center p-2 px-3 text-center text-current",
+          "group inline-flex cursor-pointer items-center rounded-lg p-2 px-3 text-center text-current",
           props.className
         )}
         tabIndex={0}


### PR DESCRIPTION
Add missing `rounded-lg` border from the two icons in the navbar `SocialLinks`. See issue in the image attached below:

<img width="268" alt="image" src="https://user-images.githubusercontent.com/11270438/191161107-6acbd4b5-2d46-43a5-bcb7-5dc0d2504766.png">

<img width="256" alt="image" src="https://user-images.githubusercontent.com/11270438/191161112-4a930170-4143-4857-b1fb-4e5e85148b18.png">

<img width="278" alt="image" src="https://user-images.githubusercontent.com/11270438/191161118-580a0807-3d85-44ee-b9f8-6944771ecdef.png">

<img width="301" alt="image" src="https://user-images.githubusercontent.com/11270438/191161125-fe3d565f-1fb4-48f9-9280-984910285c63.png">
