### PR TITLE
Improve identity signals and unify Writing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import { defineConfig } from "astro/config";
 
 export default defineConfig({
   integrations: [mdx(), react(), sitemap()],
-  site: "https://shrirambalaji.com",
+  site: "https://www.shrirambalaji.com",
 
   vite: {
     plugins: [tailwindcss()],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
-Sitemap: https://shrirambalaji.com/sitemap-index.xml
+Sitemap: https://www.shrirambalaji.com/sitemap-index.xml
+Sitemap: https://www.shrirambalaji.com/writing/sitemap.xml

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -372,7 +372,7 @@ const MobileNav = ({ currentPath, items }: Props) => {
           : "pointer-events-none opacity-0"
       }`}
     >
-      <div className="mx-auto flex min-h-screen w-full max-w-145.5 flex-col px-6 pt-4 pb-10 md:px-4 md:pt-[2.9rem] md:pb-13">
+      <div className="mx-auto flex min-h-screen w-full max-w-[46.5rem] flex-col px-6 pt-4 pb-10 md:px-4 md:pt-[2.9rem] md:pb-13">
         <div className="mt-0.5 mb-7 flex items-center justify-between py-[0.65rem] font-medium text-muted-soft text-sm">
           <span>Navigate</span>
           <button

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -22,6 +22,7 @@ const site = defineCollection({
     }),
     meta: z.object({
       description: z.string(),
+      seoTitle: z.string(),
       title: z.string(),
       url: z.url(),
     }),

--- a/src/content/home/intro.mdx
+++ b/src/content/home/intro.mdx
@@ -1,8 +1,8 @@
 ---
 ---
 
-I work as a Senior Software Engineer at [Microsoft](https://www.microsoft.com/), where I build distributed systems for the Microsoft 365 Data & Compute Platform. Previously, I worked on developer tooling at [NetApp](https://www.netapp.com/) and messaging systems at [Cisco](https://www.cisco.com/).
+I'm Shriram Balaji, a Senior Software Engineer at [Microsoft](https://www.microsoft.com/), where I build distributed systems for the Microsoft 365 Data & Compute Platform. Previously, I worked on developer tooling at [NetApp](https://www.netapp.com/) and messaging systems at [Cisco](https://www.cisco.com/).
 
-I enjoy reading about databases, linkers, compilers, distributed systems and more. I occasionally write about my learnings on [my blog](https://blog.shrirambalaji.com/).
+I enjoy reading about databases, linkers, compilers, distributed systems and more. I occasionally share my learnings in [Writing](/writing).
 I've been having fun with Rust lately and contribute to open source projects while building [side projects](/#projects) that interest me.
 I really like visual diagramming tools, and spend a lot of time obsessing over tiny details.

--- a/src/content/site/config.json
+++ b/src/content/site/config.json
@@ -1,8 +1,9 @@
 {
   "meta": {
     "title": "Shriram Balaji",
-    "description": "Senior software engineer building distributed systems, developer tools, and polished side projects.",
-    "url": "https://shrirambalaji.com"
+    "seoTitle": "Shriram Balaji, Software Engineer at Microsoft",
+    "description": "Shriram Balaji is a Senior Software Engineer at Microsoft building distributed systems for the Microsoft 365 Data & Compute Platform.",
+    "url": "https://www.shrirambalaji.com"
   },
   "identity": {
     "alternateName": "shrirambalaji",

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -18,7 +18,7 @@ const {
 } = Astro.props;
 
 const pageTitle =
-  title === siteMeta.title ? title : `${title} · ${siteMeta.title}`;
+  title === siteMeta.title ? siteMeta.seoTitle : `${title} · ${siteMeta.title}`;
 const footerLinkClasses = "footer-link transition-colors duration-150";
 ---
 
@@ -48,7 +48,7 @@ const footerLinkClasses = "footer-link transition-colors duration-150";
     class="min-h-screen bg-paper font-sans text-base leading-tight text-ghostindigo-800"
   >
     <div
-      class="mx-auto max-w-145.5 px-4 pb-10 pt-4 md:px-4 md:pb-13 md:pt-[2.9rem] xl:max-w-178"
+      class="mx-auto max-w-[46.5rem] px-4 pb-10 pt-4 md:px-4 md:pb-13 md:pt-[2.9rem]"
     >
       <div class="scroll-blur" aria-hidden="true"></div>
       <header

--- a/src/lib/blog-rss.ts
+++ b/src/lib/blog-rss.ts
@@ -9,6 +9,11 @@ export interface BlogPost {
 }
 
 const BLOG_RSS_URL = "https://blog.shrirambalaji.com/rss.xml";
+const BLOG_HOSTS = new Set([
+  "blog.shrirambalaji.com",
+  "shrirambalaji.com",
+  "www.shrirambalaji.com",
+]);
 
 const parser = new XMLParser({
   ignoreAttributes: true,
@@ -38,6 +43,29 @@ interface ParsedFeed {
   };
 }
 
+export const toWritingPath = (value: string): string => {
+  const url = new URL(value, BLOG_RSS_URL);
+
+  if (!BLOG_HOSTS.has(url.hostname)) {
+    return "";
+  }
+
+  const path = url.pathname.replace(/\/$/, "");
+  if (path === "/writing" || path.startsWith("/writing/")) {
+    return `${path}${url.search}${url.hash}`;
+  }
+
+  if (path === "/posts") {
+    return "/writing/posts";
+  }
+
+  if (path.startsWith("/posts/")) {
+    return `/writing/posts/${path.slice("/posts/".length)}${url.search}${url.hash}`;
+  }
+
+  return "";
+};
+
 const asArray = <T>(value?: T | T[]): T[] => {
   if (!value) {
     return [];
@@ -53,7 +81,7 @@ export const parseBlogFeed = (xml: string): BlogPost[] => {
   return items
     .map((item) => {
       const title = stripMarkup(item.title ?? "");
-      const href = stripMarkup(item.link ?? "");
+      const href = toWritingPath(stripMarkup(item.link ?? ""));
       const description = stripMarkup(item.description ?? "");
       const publishedAt = stripMarkup(item.pubDate ?? "");
       const publishedTime = new Date(publishedAt).getTime();

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -112,8 +112,6 @@ const homepageStructuredData = serializeStructuredData(
             <a
               class={detailLinkClass}
               href={item.href}
-              target="_blank"
-              rel="noreferrer"
             >
               <div class="min-w-0">
                 <p class={writingDateClass}>
@@ -137,9 +135,7 @@ const homepageStructuredData = serializeStructuredData(
       <li>
         <a
           class={detailLinkClass}
-          href="https://blog.shrirambalaji.com/posts"
-          target="_blank"
-          rel="noreferrer"
+          href="/writing"
         >
           <div class="min-w-0">
             <h2 class={detailCopyHeadingClass}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -93,6 +93,10 @@ html {
 
 body {
   -webkit-font-smoothing: antialiased;
+  font-feature-settings:
+    "calt" 1,
+    "tnum" 1,
+    "ss03" 1;
   text-rendering: optimizeLegibility;
 }
 

--- a/tests/site.spec.ts
+++ b/tests/site.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { getRecentBlogPosts } from "../src/lib/blog-rss";
+import { getRecentBlogPosts, toWritingPath } from "../src/lib/blog-rss";
 
 const PROJECTS_HASH_RE = /\/#projects$/;
 const WRITING_HASH_RE = /\/#writing$/;
@@ -14,6 +14,20 @@ const PAPER_MONO_RE = /Paper Mono/;
 const NON_EMPTY_RE = /.+/;
 const BLUR_RE = /blur/;
 
+test("blog URLs are normalized to the same-origin writing path", () => {
+  expect(
+    toWritingPath(
+      "https://blog.shrirambalaji.com/posts/resolving-rust-symbols/"
+    )
+  ).toBe("/writing/posts/resolving-rust-symbols");
+  expect(
+    toWritingPath(
+      "https://www.shrirambalaji.com/writing/posts/resolving-rust-symbols/"
+    )
+  ).toBe("/writing/posts/resolving-rust-symbols");
+  expect(toWritingPath("https://example.com/posts/untrusted")).toBe("");
+});
+
 test("homepage publishes canonical person structured data", async ({
   page,
 }) => {
@@ -21,8 +35,18 @@ test("homepage publishes canonical person structured data", async ({
 
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
-    "https://shrirambalaji.com/"
+    "https://www.shrirambalaji.com/"
   );
+  await expect(page).toHaveTitle(
+    "Shriram Balaji, Software Engineer at Microsoft"
+  );
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+    "content",
+    "Shriram Balaji is a Senior Software Engineer at Microsoft building distributed systems for the Microsoft 365 Data & Compute Platform."
+  );
+  await expect(
+    page.getByText("I’m Shriram Balaji", { exact: false })
+  ).toBeVisible();
 
   const jsonLd = await page
     .locator('script[type="application/ld+json"]')
@@ -43,14 +67,14 @@ test("homepage publishes canonical person structured data", async ({
   );
 
   expect(profilePage).toMatchObject({
-    "@id": "https://shrirambalaji.com/#profile",
-    mainEntity: { "@id": "https://shrirambalaji.com/#person" },
-    url: "https://shrirambalaji.com",
+    "@id": "https://www.shrirambalaji.com/#profile",
+    mainEntity: { "@id": "https://www.shrirambalaji.com/#person" },
+    url: "https://www.shrirambalaji.com",
   });
   expect(person).toMatchObject({
-    "@id": "https://shrirambalaji.com/#person",
+    "@id": "https://www.shrirambalaji.com/#person",
     alternateName: "shrirambalaji",
-    image: "https://shrirambalaji.com/images/shriram-balaji.jpg",
+    image: "https://www.shrirambalaji.com/images/shriram-balaji.jpg",
     jobTitle: "Senior Software Engineer",
     name: "Shriram Balaji",
     sameAs: [
@@ -71,7 +95,7 @@ test("robots metadata points at the generated sitemap", async ({ request }) => {
 
   expect(robotsResponse.ok()).toBe(true);
   expect(await robotsResponse.text()).toContain(
-    "Sitemap: https://shrirambalaji.com/sitemap-index.xml"
+    "Sitemap: https://www.shrirambalaji.com/sitemap-index.xml"
   );
 });
 
@@ -147,12 +171,13 @@ test("core pages render and navigation works", async ({ page }) => {
   ).toBeVisible();
   await expect(
     writingSection.getByRole("link", { name: latestBlogPost.title })
-  ).toBeVisible();
+  ).toHaveAttribute("href", latestBlogPost.href);
+  await expect(
+    writingSection.getByRole("link", { name: latestBlogPost.title })
+  ).not.toHaveAttribute("target", NON_EMPTY_RE);
   await expect(writingSection.getByText(latestBlogPostDate)).toBeVisible();
   await expect(
-    writingSection
-      .locator('a[href="https://blog.shrirambalaji.com/posts"]')
-      .first()
+    writingSection.locator('a[href="/writing"]').first()
   ).toBeVisible();
   await expect(projectsNav).toHaveAttribute("aria-current", "location");
   await expect(aboutNav).not.toHaveAttribute("aria-current", NON_EMPTY_RE);

--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,17 @@
-{}
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/writing/rss.xml",
+      "destination": "https://blog.shrirambalaji.com/rss.xml"
+    },
+    {
+      "source": "/writing",
+      "destination": "https://blog.shrirambalaji.com/writing"
+    },
+    {
+      "source": "/writing/:path*",
+      "destination": "https://blog.shrirambalaji.com/writing/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- strengthen Shriram Balaji identity signals with a descriptive homepage title, canonical www URL, visible name introduction, and consistent structured data
- route /writing, article paths, RSS, and sitemap requests through the deployed blog origin while keeping the public URL on shrirambalaji.com
- normalize blog feed links to same-origin /writing/posts paths
- update homepage writing links to stay in the same browsing context
- advertise both the portfolio and writing sitemaps in robots.txt
- include the shared typography and layout refinements already prepared on the branch

## Upstream dependency

- blog.shrirambalaji.com PR #36 is merged and live with /writing/posts routes, canonical URLs, absolute asset URLs, legacy redirects, RSS, and sitemap output

## Validation

- pnpm lint
- pnpm check
- pnpm build
- pnpm test:e2e
- blog production browser validation for article canonical, CSS and script origins, and console errors

## Deployment validation

After the Vercel preview is ready, verify /writing, a representative /writing/posts article, /writing/rss.xml, and /writing/sitemap.xml through the portfolio deployment.