### PR TITLE
Redirect Writing directly to posts

### DIFF
--- a/src/content/home/intro.mdx
+++ b/src/content/home/intro.mdx
@@ -3,6 +3,6 @@
 
 I'm Shriram Balaji, a Senior Software Engineer at [Microsoft](https://www.microsoft.com/), where I build distributed systems for the Microsoft 365 Data & Compute Platform. Previously, I worked on developer tooling at [NetApp](https://www.netapp.com/) and messaging systems at [Cisco](https://www.cisco.com/).
 
-I enjoy reading about databases, linkers, compilers, distributed systems and more. I occasionally share my learnings in [Writing](/writing).
+I enjoy reading about databases, linkers, compilers, distributed systems and more. I occasionally share my learnings in [Writing](/writing/posts).
 I've been having fun with Rust lately and contribute to open source projects while building [side projects](/#projects) that interest me.
 I really like visual diagramming tools, and spend a lot of time obsessing over tiny details.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -135,7 +135,7 @@ const homepageStructuredData = serializeStructuredData(
       <li>
         <a
           class={detailLinkClass}
-          href="/writing"
+          href="/writing/posts"
         >
           <div class="min-w-0">
             <h2 class={detailCopyHeadingClass}>

--- a/tests/site.spec.ts
+++ b/tests/site.spec.ts
@@ -177,7 +177,7 @@ test("core pages render and navigation works", async ({ page }) => {
   ).not.toHaveAttribute("target", NON_EMPTY_RE);
   await expect(writingSection.getByText(latestBlogPostDate)).toBeVisible();
   await expect(
-    writingSection.locator('a[href="/writing"]').first()
+    writingSection.locator('a[href="/writing/posts"]').first()
   ).toBeVisible();
   await expect(projectsNav).toHaveAttribute("aria-current", "location");
   await expect(aboutNav).not.toHaveAttribute("aria-current", NON_EMPTY_RE);

--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,16 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    {
+      "source": "/writing",
+      "destination": "/writing/posts",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     {
       "source": "/writing/rss.xml",
       "destination": "https://blog.shrirambalaji.com/rss.xml"
-    },
-    {
-      "source": "/writing",
-      "destination": "https://blog.shrirambalaji.com/writing"
     },
     {
       "source": "/writing/:path*",


### PR DESCRIPTION
## Summary

- change the portfolio Writing links to /writing/posts
- add a permanent Vercel redirect from /writing to /writing/posts
- remove the /writing external rewrite that served the generated Astro redirect document
- update the homepage route test for the direct destination

## Validation

- pnpm lint
- pnpm check
- pnpm build
- portfolio browser suite, with the timing-sensitive navigation scenario passing twice on rerun

## Deployment order

Merge after the blog redirect cleanup so every upstream writing entry point resolves directly.